### PR TITLE
Fix path to supervisord.conf templates.

### DIFF
--- a/production.cfg
+++ b/production.cfg
@@ -12,6 +12,6 @@ API_ENV = production
 
 [supervisord.conf]
 recipe = collective.recipe.template
-input = etc/${environment:API_SERVER_NAME}/supervisord.conf
+input = etc/supervisord.conf.${environment:API_ENV}
 output = supervisord.conf
 API_ENV = ${environment:API_ENV}

--- a/staging.cfg
+++ b/staging.cfg
@@ -12,6 +12,6 @@ API_ENV = staging
 
 [supervisord.conf]
 recipe = collective.recipe.template
-input = etc/${environment:API_SERVER_NAME}/supervisord.conf
+input = etc/supervisord.conf.${environment:API_ENV}
 output = supervisord.conf
 API_ENV = ${environment:API_ENV}

--- a/testing.cfg
+++ b/testing.cfg
@@ -12,7 +12,7 @@ API_ENV = testing
 
 [supervisord.conf]
 recipe = collective.recipe.template
-input = etc/${environment:API_SERVER_NAME}/supervisord.conf
+input = etc/supervisord.conf.${environment:API_ENV}
 output = supervisord.conf
 API_ENV = ${environment:API_ENV}
 


### PR DESCRIPTION
The configuration files testing.cfg, staging.cfg and production.cfg use a wrong path to the supervisord.conf template (`etc/${environment:API_SERVER_NAME}/supervisord.conf`). The right one given the current structure of etc/ is `etc/supervisord.conf.${environment:API_ENV}`.
