### PR TITLE
Add a parameter to the server Application for enabling specific endpo…

### DIFF
--- a/api/docs/deployment.rst
+++ b/api/docs/deployment.rst
@@ -42,15 +42,14 @@ To start the `server` instance that will serve all supported endpoints.
 ::
 
     bin/start_server
-    usage: start_server [-h] [--settings SETTINGS] [--name NAME] [--port PORT]
+    usage: start_server [-h] [--name NAME] [--port PORT] [--settings SETTINGS] [--endpoint ENDPOINTS]
 
 
-To start process with the specific `endpoint` only (from the list of registered endpoints):
+To start process with one or more specific `endpoint`s only (from the list of registered endpoints):
 
 ::
 
-    bin/start_endpoint search 5788
-    usage: start_endpoint [-h] [--settings SETTINGS] name port
+    bin/start_server --port 5788 --endpoint issues --endpoint search
 
 
 To generate the documentation:

--- a/api/endpoints/base.py
+++ b/api/endpoints/base.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import redis
 import tornado.web
 
-from tornado.concurrent import futures
-
-from ..handlers import DeprecatedHandler, RequestHandler
+from ..handlers import RequestHandler
 from ..utils.access import authenticated
-from ..utils.ops import build_versioned_handlers
 
 
 class BaseEndpoint(object):
@@ -16,31 +12,6 @@ class BaseEndpoint(object):
     @classmethod
     def from_settings(cls, settings):
         return cls(settings)
-
-
-class BaseEndpointApplication(tornado.web.Application):
-    """Base class for Endpoint Application."""
-
-    def __init__(self, endpoint_cls, endpoint_handlers, **settings):
-        # TODO: initalize clients for DB, ES, etc. here
-        # for available in the case then endpoints executed
-        # without server (standalone)
-        # NOTE: for server case, see api.server.__init__
-
-        self._executor = futures.ThreadPoolExecutor(
-            settings["concurrency"].get("threads", 1))
-        self._redis = redis.StrictRedis.from_url(
-            settings["redis"]["url"])
-
-        endpoint = endpoint_cls.from_settings(settings)
-        handlers = build_versioned_handlers(
-            endpoint,
-            endpoint_handlers,
-            settings["api_version"],
-            settings["deprecated_api_versions"],
-            DeprecatedHandler)
-
-        tornado.web.Application.__init__(self, handlers, **settings)
 
 
 class BaseEndpointHandler(RequestHandler):

--- a/api/endpoints/document/__init__.py
+++ b/api/endpoints/document/__init__.py
@@ -2,10 +2,7 @@
 
 import tornado.gen
 
-from ..base import (
-    BaseEndpoint,
-    BaseEndpointApplication
-)
+from ..base import BaseEndpoint
 
 from .executors import DocumentEndpointExecutor
 from .handlers import (
@@ -60,11 +57,3 @@ class Endpoint(BaseEndpoint):
             test=getattr(request_handler, "__is_test", None))
         result = executor.delete(document_id)
         raise tornado.gen.Return(result)
-
-
-class Application(BaseEndpointApplication):
-    """Main application for /document endpoint namespace."""
-
-    def __init__(self, **settings):
-        super(Application, self).__init__(
-            Endpoint, ENDPOINT_HANDLERS, **settings)

--- a/api/start.py
+++ b/api/start.py
@@ -10,9 +10,8 @@ import tornado.ioloop
 from .settings import settings
 from .server import Application as ServerApplication
 from .utils import merge
-from .utils.ops import get_endpoint_app
 
-__all__ = ['start_server', 'start_endpoint']
+__all__ = ['start_server']
 
 logger = logging.getLogger('api.start')
 
@@ -23,6 +22,7 @@ def start_server():
     arg_parser.add_argument('--name', dest='name')
     arg_parser.add_argument('--port', dest='port', type=int, default=None)
     arg_parser.add_argument('--settings', dest='settings', default='{}')
+    arg_parser.add_argument('--endpoint', dest='endpoints', action='append')
     args = arg_parser.parse_args()
 
     name = args.name or settings['default_server_name']
@@ -32,42 +32,10 @@ def start_server():
 
     try:
         logger.info("Starting server '%s' on port %i", name, port)
-        application = ServerApplication(**server_settings)
+        application = ServerApplication(endpoints=args.endpoints,
+                                        **server_settings)
         application.listen(port)
         tornado.ioloop.IOLoop.instance().start()
     except:
         logger.exception("Failed to start server '%s' on port %i", name, port)
         sys.exit(errno.EINTR)
-
-
-def start_endpoint():
-    """Start process for a specific endpoint."""
-    arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('name')
-    arg_parser.add_argument('port', type=int)
-    arg_parser.add_argument('--settings', dest='settings', default='{}')
-    args = arg_parser.parse_args()
-
-    name = args.name
-    port = args.port
-    endpoint_settings = json.loads(args.settings)
-    endpoint_settings = merge(settings, endpoint_settings)
-
-    if name not in settings['registered_endpoints']:
-        logger.info("Unsupported endpoint '%s'", name)
-        logger.info("Possible values: %s",
-                    json.dumps(settings['registered_endpoints']))
-        sys.exit(errno.EACCES)
-
-    try:
-        logger.info("Starting server '%s' on port %i", name, port)
-        application = get_endpoint_app(name)(**endpoint_settings)
-        application.listen(port)
-        tornado.ioloop.IOLoop.instance().start()
-    except:
-        logger.exception("Failed to start server '%s' on port %i", name, port)
-        sys.exit(errno.EINTR)
-
-
-if __name__ == '__main__':
-    start_server()

--- a/api/utils/ops.py
+++ b/api/utils/ops.py
@@ -4,7 +4,6 @@ import re
 
 __all__ = [
     'build_versioned_handlers',
-    'get_endpoint_app',
     'resolve_name'
 ]
 
@@ -67,12 +66,6 @@ def build_versioned_handlers(endpoint, handlers, active_version,
                     (deprecated_path, deprecated_handler)
                 )
     return versioned
-
-
-def get_endpoint_app(name):
-    """Return Application class for the endpoint."""
-    module = resolve_name('api.endpoints.' + name)
-    return getattr(module, 'Application')
 
 
 def resolve_name(name):

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(
     zip_safe=False,
     entry_points={
         "console_scripts": [
-            "start_server = api.start:start_server",
-            "start_endpoint = api.start:start_endpoint",
+            "start_server = api.start:start_server"
         ]
     }
 )

--- a/tests/test_api/test_service.py
+++ b/tests/test_api/test_service.py
@@ -7,7 +7,7 @@ from time import time
 from tornado.testing import get_unused_port
 from unittest import TestCase
 
-from api.start import start_server, start_endpoint
+from api.start import start_server
 
 
 class ServiceTest(TestCase):
@@ -22,6 +22,7 @@ class ServiceTest(TestCase):
         args.name = None
         args.port = get_unused_port()
         args.settings = "{}"
+        args.endpoints = None
         mock_parse_args.return_value = args
 
         start_server()
@@ -36,6 +37,7 @@ class ServiceTest(TestCase):
         args.name = "test"
         args.port = get_unused_port()
         args.settings = "{}"
+        args.endpoints = None
         mock_parse_args.return_value = args
 
         start_server()
@@ -47,12 +49,12 @@ class ServiceTest(TestCase):
         mock_ioloop.current.return_value = mock_ioloop
 
         args = mock.MagicMock()
-        args.name = "document"
         args.port = get_unused_port()
         args.settings = "{}"
+        args.endpoints = ["document"]
         mock_parse_args.return_value = args
 
-        start_endpoint()
+        start_server()
 
     @mock.patch('sys.exit')
     @mock.patch('argparse.ArgumentParser.parse_args')
@@ -63,14 +65,15 @@ class ServiceTest(TestCase):
         mock_ioloop.current.return_value = mock_ioloop
 
         args = mock.MagicMock()
-        args.name = "nonregistered"
         args.port = get_unused_port()
         args.settings = "{}"
+        args.endpoints = ["nonregistered"]
         mock_parse_args.return_value = args
 
         def side_effect(value):
             raise Exception(value)
+
         mock_exit.side_effect = side_effect
 
-        with self.assertRaisesRegexp(Exception, str(errno.EACCES)):
-            start_endpoint()
+        with self.assertRaisesRegexp(Exception, str(errno.EINTR)):
+            start_server()

--- a/tests/test_api/utils/test_ops.py
+++ b/tests/test_api/utils/test_ops.py
@@ -4,7 +4,6 @@ import unittest
 from api.utils.ops import (
     _is_versioned_path,
     build_versioned_handlers,
-    get_endpoint_app,
     resolve_name
 )
 
@@ -129,9 +128,3 @@ class TestUtilsOps(unittest.TestCase):
     def test_resolve_name_empty(self):
         with self.assertRaises(ValueError):
             resolve_name("")
-
-    def test_get_endpoint_app(self):
-        name = "document"
-        app = get_endpoint_app(name)
-        self.assertIsNotNone(app)
-        self.assertEqual(app.__name__, "Application")


### PR DESCRIPTION
…ints.

This renders BaseEndpointApplication obsolete, and with it all (trivial)
Application classes that had to be defined for each endpoint.

Another nice side effect is that the server can now be started with a
subset of its endpoints instead of all vs. just one.