### PR TITLE
Refactor endpoints and the generation of endpoint paths.

### DIFF
--- a/api/endpoints/base.py
+++ b/api/endpoints/base.py
@@ -9,9 +9,13 @@ from ..utils.access import authenticated
 class BaseEndpoint(object):
     """Base class for Endpoints."""
 
-    @classmethod
-    def from_settings(cls, settings):
-        return cls(settings)
+    def __init__(self, name, settings):
+        self.name = name
+        self.settings = settings
+
+    @property
+    def handlers(self):
+        return []
 
 
 class BaseEndpointHandler(RequestHandler):

--- a/api/endpoints/document/__init__.py
+++ b/api/endpoints/document/__init__.py
@@ -11,20 +11,17 @@ from .handlers import (
 )
 
 
-ENDPOINT_HANDLERS = [
-    (r'/document', DocumentCreateHandler),
-    (r'/document/(?P<document_id>[^/]+)', DocumentHandler),
-]
-
-
 class Endpoint(BaseEndpoint):
     """Base class for /document endpoint namespace."""
 
-    name = 'document'
     version = '1.0.0'
 
-    def __init__(self, settings):
-        self._settings = settings
+    @property
+    def handlers(self):
+        return [
+            (r'/', DocumentCreateHandler),
+            (r'/(?P<document_id>[^/]+)', DocumentHandler),
+        ]
 
     @tornado.gen.coroutine
     def get_document(self, request_handler, document_id):

--- a/api/endpoints/document/__init__.py
+++ b/api/endpoints/document/__init__.py
@@ -19,7 +19,7 @@ class Endpoint(BaseEndpoint):
     @property
     def handlers(self):
         return [
-            (r'/', DocumentCreateHandler),
+            (r'', DocumentCreateHandler),
             (r'/(?P<document_id>[^/]+)', DocumentHandler),
         ]
 

--- a/api/server/__init__.py
+++ b/api/server/__init__.py
@@ -44,15 +44,14 @@ class Application(tornado.web.Application):
 
         endpoint_versions = {}
         for name in self._endpoints:
-            module = resolve_name("api.endpoints." + name)
-            endpoint = getattr(module, "Endpoint").from_settings(settings)
+            endpoint_module = resolve_name("api.endpoints." + name)
+            endpoint_cls = getattr(endpoint_module, "Endpoint")
+            endpoint = endpoint_cls(name, settings)
             endpoint_versions[endpoint.name] = endpoint.version
 
-            endpoint_handlers = getattr(module, "ENDPOINT_HANDLERS")
             handlers.extend(
                 build_versioned_handlers(
                     endpoint,
-                    endpoint_handlers,
                     settings["api_version"],
                     settings["deprecated_api_versions"],
                     DeprecatedHandler)

--- a/tests/test_api/utils/test_ops.py
+++ b/tests/test_api/utils/test_ops.py
@@ -1,34 +1,19 @@
 # -*- encoding: utf-8 -*-
 import unittest
+from unittest.mock import MagicMock
 
 from api.utils.ops import (
-    _is_versioned_path,
     build_versioned_handlers,
     resolve_name
 )
 
 
 class TestUtilsOps(unittest.TestCase):
-    def test_is_versioned_path(self):
-        path = "/v1/test"
-
-        is_versioned = _is_versioned_path(path)
-        self.assertTrue(is_versioned)
-
-    def test_is_versioned_path_not_versioned(self):
-        path = "/test"
-
-        is_versioned = _is_versioned_path(path)
-        self.assertFalse(is_versioned)
-
-    def test_is_versioned_path_almost_versioned(self):
-        path = "/vq/test"
-
-        is_versioned = _is_versioned_path(path)
-        self.assertFalse(is_versioned)
 
     def test_build_versioned_handlers(self):
-        handlers = [
+        endpoint = MagicMock()
+        endpoint.name = "foobar"
+        endpoint.handlers = [
             ("/test0", "TEST0"),
             ("/test1", "TEST1"),
         ]
@@ -36,22 +21,23 @@ class TestUtilsOps(unittest.TestCase):
         deprecated_versions = ['1']
         deprecated_handler = "DEPRECATED"
         expected = [
-            ("/v2/test0", "TEST0", {"endpoint": None}),
-            ("/v2/test1", "TEST1", {"endpoint": None}),
-            ("/v1/test0", "DEPRECATED"),
-            ("/v1/test1", "DEPRECATED"),
+            ("/v2/foobar/test0", "TEST0", {"endpoint": endpoint}),
+            ("/v2/foobar/test1", "TEST1", {"endpoint": endpoint}),
+            ("/v1/foobar/test0", "DEPRECATED"),
+            ("/v1/foobar/test1", "DEPRECATED"),
         ]
 
         versioned = build_versioned_handlers(
-            None,
-            handlers,
+            endpoint,
             active_version,
             deprecated_versions,
             deprecated_handler)
         self.assertEqual(versioned, expected)
 
     def test_build_versioned_handlers_long_handler(self):
-        handlers = [
+        endpoint = MagicMock()
+        endpoint.name = "foobar"
+        endpoint.handlers = [
             ("/test0", "TEST0", {"ADDITIONAL": True}),
             ("/test1", "TEST1"),
         ]
@@ -59,22 +45,24 @@ class TestUtilsOps(unittest.TestCase):
         deprecated_versions = ['1']
         deprecated_handler = "DEPRECATED"
         expected = [
-            ("/v2/test0", "TEST0", {"ADDITIONAL": True, "endpoint": None}),
-            ("/v2/test1", "TEST1", {"endpoint": None}),
-            ("/v1/test0", "DEPRECATED"),
-            ("/v1/test1", "DEPRECATED"),
+            ("/v2/foobar/test0", "TEST0", {"ADDITIONAL": True,
+                                           "endpoint": endpoint}),
+            ("/v2/foobar/test1", "TEST1", {"endpoint": endpoint}),
+            ("/v1/foobar/test0", "DEPRECATED"),
+            ("/v1/foobar/test1", "DEPRECATED"),
         ]
 
         versioned = build_versioned_handlers(
-            None,
-            handlers,
+            endpoint,
             active_version,
             deprecated_versions,
             deprecated_handler)
         self.assertEqual(versioned, expected)
 
     def test_build_versioned_handlers_no_deprecated(self):
-        handlers = [
+        endpoint = MagicMock()
+        endpoint.name = "foobar"
+        endpoint.handlers = [
             ("/test0", "TEST0"),
             ("/test1", "TEST1"),
         ]
@@ -82,35 +70,12 @@ class TestUtilsOps(unittest.TestCase):
         deprecated_versions = []
         deprecated_handler = "DEPRECATED"
         expected = [
-            ("/v2/test0", "TEST0", {"endpoint": None}),
-            ("/v2/test1", "TEST1", {"endpoint": None}),
+            ("/v2/foobar/test0", "TEST0", {"endpoint": endpoint}),
+            ("/v2/foobar/test1", "TEST1", {"endpoint": endpoint}),
         ]
 
         versioned = build_versioned_handlers(
-            None,
-            handlers,
-            active_version,
-            deprecated_versions,
-            deprecated_handler)
-        self.assertEqual(versioned, expected)
-
-    def test_build_versioned_handlers_not_override_deprecated(self):
-        handlers = [
-            ("/test0", "TEST0"),
-            ("/v1/test1", "TEST1"),
-        ]
-        active_version = '2'
-        deprecated_versions = ['1']
-        deprecated_handler = "DEPRECATED"
-        expected = [
-            ("/v2/test0", "TEST0", {"endpoint": None}),
-            ("/v1/test1", "TEST1", {"endpoint": None}),
-            ("/v1/test0", "DEPRECATED"),
-        ]
-
-        versioned = build_versioned_handlers(
-            None,
-            handlers,
+            endpoint,
             active_version,
             deprecated_versions,
             deprecated_handler)


### PR DESCRIPTION
Endpoint names are now passed to their respective endpoints instead
of being defined as class attributes. This reduces duplication as
names are actually determined by the containing module.

Endpoints specify their handlers via property. Benefits:
Instantiating endpoints does not require additional imports of
module constants. And the use of properties makes it possible to
specify handlers dynamically (e.g., based on settings or other
runtime information).

Lastly, endpoints must no longer add their names to handler paths.
Just like the API version, endpoint names are added automatically
to all relevant paths.