### PR TITLE
Add health check capabilities to endpoints.

### DIFF
--- a/api/endpoints/base.py
+++ b/api/endpoints/base.py
@@ -1,9 +1,17 @@
 # -*- coding: utf-8 -*-
 
-import tornado.web
+from operator import attrgetter
+from operator import itemgetter
 
+from tornado.gen import Return
+from tornado.gen import coroutine
+
+from ..exceptions import HealthError
+from ..exceptions import HealthWarning
 from ..handlers import RequestHandler
 from ..utils.access import authenticated
+from ..utils.schema import output_validate
+from .schema import HEALTH_SCHEMA
 
 
 class BaseEndpoint(object):
@@ -12,10 +20,55 @@ class BaseEndpoint(object):
     def __init__(self, name, settings):
         self.name = name
         self.settings = settings
+        self._health_checks = {}
 
     @property
     def handlers(self):
         return []
+
+    @property
+    def health_checks(self):
+        return self._health_checks.copy()
+
+    def add_health_check(self, name, check):
+        if not name:
+            raise ValueError("name must not be empty")
+
+        self._health_checks[name] = check
+        return self
+
+    @coroutine
+    def check_health(self):
+        checks = []
+        caugth = []
+        for name, check in self._health_checks.items():
+            result = {"name": name}
+            try:
+                yield check()
+            except (HealthError, HealthWarning) as exc:
+                caugth.append(exc)
+                if exc.details:
+                    result.update(exc.details)
+
+                result.update({
+                    "status": exc.status,
+                    "reason": str(exc)
+                })
+            else:
+                result["status"] = "ok"
+
+            checks.append(result)
+
+        if not caugth:
+            status = "ok"
+        else:
+            status = max(caugth, key=attrgetter("weight")).status
+
+        checks.sort(key=itemgetter("name"))
+        raise Return({
+            "status": status,
+            "checks": checks
+        })
 
 
 class BaseEndpointHandler(RequestHandler):
@@ -28,6 +81,13 @@ class BaseEndpointHandler(RequestHandler):
         self.set_header("X-Endpoint-Version", self.endpoint.version)
 
     @authenticated()
-    @tornado.gen.coroutine
+    @coroutine
     def prepare(self, *args, **kwargs):
         return super(BaseEndpointHandler, self).prepare(*args, **kwargs)
+
+
+class HealthHandler(BaseEndpointHandler):
+
+    @output_validate(HEALTH_SCHEMA)
+    def get(self):
+        return self.endpoint.check_health()

--- a/api/endpoints/document/__init__.py
+++ b/api/endpoints/document/__init__.py
@@ -2,6 +2,7 @@
 
 import tornado.gen
 
+from ...exceptions import HealthError
 from ..base import BaseEndpoint
 
 from .executors import DocumentEndpointExecutor
@@ -15,6 +16,10 @@ class Endpoint(BaseEndpoint):
     """Base class for /document endpoint namespace."""
 
     version = '1.0.0'
+
+    def __init__(self, *args, **kwargs):
+        super(Endpoint, self).__init__(*args, **kwargs)
+        self.add_health_check("storage", self._ping_storage)
 
     @property
     def handlers(self):
@@ -54,3 +59,9 @@ class Endpoint(BaseEndpoint):
             test=getattr(request_handler, "__is_test", None))
         result = executor.delete(document_id)
         raise tornado.gen.Return(result)
+
+    @tornado.gen.coroutine
+    def _ping_storage(self):
+        pong = DocumentEndpointExecutor.ping_storage()
+        if not pong:
+            raise HealthError("Can't ping storage")

--- a/api/endpoints/document/executors/document.py
+++ b/api/endpoints/document/executors/document.py
@@ -51,3 +51,7 @@ class DocumentEndpointExecutor(object):
             "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         }
         return result
+
+    @staticmethod
+    def ping_storage():
+        return True

--- a/api/endpoints/schema.py
+++ b/api/endpoints/schema.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+__all__ = [
+    "HEALTH_SCHEMA"
+]
+
+HEALTH_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "ok",
+                "warning",
+                "error"
+            ]
+        },
+        "checks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "warning",
+                            "error"
+                        ]
+                    },
+                    "reason": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "status"
+                ]
+            }
+        }
+    },
+    "required": [
+        "status",
+        "checks"
+    ]
+}

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -21,3 +21,33 @@ class APIServerError(APIError):
     """Server API Error."""
 
     pass
+
+
+class HealthError(Exception):
+
+    def __init__(self, reason, details=None):
+        super(HealthError, self).__init__(reason)
+        self.details = details
+
+    @property
+    def status(self):
+        return "error"
+
+    @property
+    def weight(self):
+        return 2
+
+
+class HealthWarning(Exception):
+
+    def __init__(self, reason, details=None):
+        super(HealthWarning, self).__init__(reason)
+        self.details = details
+
+    @property
+    def status(self):
+        return "warning"
+
+    @property
+    def weight(self):
+        return 1

--- a/api/utils/ops.py
+++ b/api/utils/ops.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from ..endpoints.base import HealthHandler
+
 __all__ = [
     'build_versioned_handlers',
     'resolve_name'
 ]
+
+_HEALTH_PATH = "/_health"
 
 
 def build_versioned_handlers(endpoint, active_version, deprecated_versions,
@@ -29,6 +33,9 @@ def build_versioned_handlers(endpoint, active_version, deprecated_versions,
         return "/v{}/{}{}".format(version, endpoint.name, sub_path)
 
     versioned = []
+    if endpoint.health_checks:
+        versioned.append((make_path(_HEALTH_PATH), HealthHandler, settings))
+
     for handler in endpoint_handlers:
         sub_path, handler_cls, settings = handler
         versioned.append((make_path(sub_path), handler_cls, settings))

--- a/tests/test_api/endpoints/test_base.py
+++ b/tests/test_api/endpoints/test_base.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+
+from tornado.gen import coroutine
+from tornado.testing import AsyncTestCase
+from tornado.testing import gen_test
+
+from api.endpoints.base import BaseEndpoint
+from api.exceptions import HealthError
+from api.exceptions import HealthWarning
+
+
+def _make_check(status, reason=None, **details):
+
+    @coroutine
+    def check():
+        if status in ("warning", "error"):
+            if status == "warning":
+                exc_class = HealthWarning
+            else:
+                exc_class = HealthError
+
+            raise exc_class(reason, details=details)
+
+    return check
+
+
+class TestBaseEndpoint(AsyncTestCase):
+
+    def test_name(self):
+        self.assertEqual(BaseEndpoint("foobar", {}).name, "foobar")
+
+    def test_default_handlers(self):
+        self.assertEqual(BaseEndpoint("foobar", {}).handlers, [])
+
+    def test_add_health_checks(self):
+        endpoint = BaseEndpoint("foobar", {})
+        self.assertEqual(endpoint.health_checks, {})
+        check1 = _make_check("ok")
+        check2 = _make_check("ok")
+        check3 = _make_check("ok")
+        check4 = _make_check("ok")
+        endpoint.add_health_check("a", check1)
+        endpoint.add_health_check("b", check2)
+        endpoint.add_health_check("c", check3)
+        with self.assertRaises(ValueError):
+            endpoint.add_health_check("", check4)
+
+        self.assertEqual(endpoint.health_checks, {
+            "a": check1,
+            "b": check2,
+            "c": check3
+        })
+
+    @gen_test
+    def test_health_no_checks(self):
+        endpoint = BaseEndpoint("foobar", {})
+        result = yield endpoint.check_health()
+        expected = {
+            "status": "ok",
+            "checks": []
+        }
+        self.assertEqual(result, expected)
+
+    @gen_test
+    def test_health_ok(self):
+        check1 = _make_check("ok")
+        check2 = _make_check("ok")
+        check3 = _make_check("ok")
+        endpoint = BaseEndpoint("foobar", {})
+        endpoint.add_health_check("a", check1)
+        endpoint.add_health_check("b", check2)
+        endpoint.add_health_check("c", check3)
+        result = yield endpoint.check_health()
+        expected = {
+            "status": "ok",
+            "checks": [
+                {
+                    "name": "a",
+                    "status": "ok"
+                },
+                {
+                    "name": "b",
+                    "status": "ok"
+                },
+                {
+                    "name": "c",
+                    "status": "ok"
+                }
+            ]
+        }
+        self.assertEqual(result, expected)
+
+    @gen_test
+    def test_health_warning(self):
+        check1 = _make_check("ok")
+        check2 = _make_check("warning", reason="Something went wrong ...")
+        check3 = _make_check("ok")
+        endpoint = BaseEndpoint("foobar", {})
+        endpoint.add_health_check("a", check1)
+        endpoint.add_health_check("b", check2)
+        endpoint.add_health_check("c", check3)
+        result = yield endpoint.check_health()
+        expected = {
+            "status": "warning",
+            "checks": [
+                {
+                    "name": "a",
+                    "status": "ok"
+                },
+                {
+                    "name": "b",
+                    "status": "warning",
+                    "reason": "Something went wrong ..."
+                },
+                {
+                    "name": "c",
+                    "status": "ok"
+                }
+            ]
+        }
+        self.assertEqual(result, expected)
+
+    @gen_test
+    def test_health_warning_details(self):
+        check1 = _make_check("ok")
+        check2 = _make_check("warning", reason="Something went wrong ...",
+                             host="localhost", port=4567)
+        check3 = _make_check("ok")
+        endpoint = BaseEndpoint("foobar", {})
+        endpoint.add_health_check("a", check1)
+        endpoint.add_health_check("b", check2)
+        endpoint.add_health_check("c", check3)
+        result = yield endpoint.check_health()
+        expected = {
+            "status": "warning",
+            "checks": [
+                {
+                    "name": "a",
+                    "status": "ok"
+                },
+                {
+                    "name": "b",
+                    "status": "warning",
+                    "reason": "Something went wrong ...",
+                    "host": "localhost",
+                    "port": 4567
+                },
+                {
+                    "name": "c",
+                    "status": "ok"
+                }
+            ]
+        }
+        self.assertEqual(result, expected)
+
+    @gen_test
+    def test_health_error(self):
+        check1 = _make_check("ok")
+        check2 = _make_check("warning", reason="Something went wrong ...")
+        check3 = _make_check("error", reason="Something went terribly wrong!")
+        endpoint = BaseEndpoint("foobar", {})
+        endpoint.add_health_check("a", check1)
+        endpoint.add_health_check("b", check2)
+        endpoint.add_health_check("c", check3)
+        result = yield endpoint.check_health()
+        expected = {
+            "status": "error",
+            "checks": [
+                {
+                    "name": "a",
+                    "status": "ok"
+                },
+                {
+                    "name": "b",
+                    "status": "warning",
+                    "reason": "Something went wrong ..."
+                },
+                {
+                    "name": "c",
+                    "status": "error",
+                    "reason": "Something went terribly wrong!"
+                }
+            ]
+        }
+        self.assertEqual(result, expected)
+
+    @gen_test
+    def test_health_error_details(self):
+        check1 = _make_check("ok")
+        check2 = _make_check("warning", reason="Something went wrong ...")
+        check3 = _make_check("error", reason="Something went terribly wrong!",
+                             timeout=30)
+        endpoint = BaseEndpoint("foobar", {})
+        endpoint.add_health_check("a", check1)
+        endpoint.add_health_check("b", check2)
+        endpoint.add_health_check("c", check3)
+        result = yield endpoint.check_health()
+        expected = {
+            "status": "error",
+            "checks": [
+                {
+                    "name": "a",
+                    "status": "ok"
+                },
+                {
+                    "name": "b",
+                    "status": "warning",
+                    "reason": "Something went wrong ..."
+                },
+                {
+                    "name": "c",
+                    "status": "error",
+                    "reason": "Something went terribly wrong!",
+                    "timeout": 30
+                }
+            ]
+        }
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Endpoints can declare health checks. A health check is a simple
coroutine that either returns nothing, or raises a special kind
of exception (currently HealthError or HealthWarning) to indicate
issues with the tested dependency.

If an endpoint declares at least one health check, a route to
/_health will be created automatically.